### PR TITLE
Always retry alternatives.install states

### DIFF
--- a/goland/linuxenv.sls
+++ b/goland/linuxenv.sls
@@ -31,6 +31,9 @@ goland-home-alt-install:
     - link: '{{ goland.jetbrains.home }}/goland'
     - path: '{{ goland.jetbrains.realhome }}'
     - priority: {{ goland.linux.altpriority }}
+    - retry:
+        attempts: 2
+        until: True
 
 goland-home-alt-set:
   alternatives.set:
@@ -38,6 +41,9 @@ goland-home-alt-set:
     - path: {{ goland.jetbrains.realhome }}
     - onchanges:
       - alternatives: goland-home-alt-install
+    - retry:
+        attempts: 2
+        until: True
 
 # Add to alternatives system
 goland-alt-install:
@@ -49,6 +55,9 @@ goland-alt-install:
     - require:
       - alternatives: goland-home-alt-install
       - alternatives: goland-home-alt-set
+    - retry:
+        attempts: 2
+        until: True
 
 goland-alt-set:
   alternatives.set:
@@ -56,6 +65,9 @@ goland-alt-set:
     - path: {{ goland.jetbrains.realcmd }}
     - onchanges:
       - alternatives: goland-alt-install
+    - retry:
+        attempts: 2
+        until: True
 
   {% endif %}
 

--- a/goland/map.jinja
+++ b/goland/map.jinja
@@ -22,10 +22,10 @@
 {% endif %}
 
 # Get dynamic release metadata
-{%- set pcode = pcode ~ ide.jetbrains.edition %}
-{% if grains.os == 'MacOS' or ide.jetbrains.edition in ('None',) %}
-   {%- set pcode = ide.jetbrains.product %}
-{% endif %}
+{%- set pcode = ide.jetbrains.product %}
+{%- if grains.os != 'MacOS' %}
+    {%- set pcode = pcode ~ ide.jetbrains.edition if ide.jetbrains.edition else pcode %}
+{%- endif %}
 {%- set jdata = salt['cmd.run']('curl {0} {1}{2}'.format(ide.dl.opts, ide.jetbrains.uri, pcode))|load_yaml %}
 
 # Extact download details


### PR DESCRIPTION
This PR introduces retries because salt `alternatives.install` always fails on 1st run.

Verified on SuSE